### PR TITLE
Fixes #3 by making parsing loop async

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -105,7 +105,9 @@ exports.parseFtpEntries = function parseFtpEntries(listing, callback) {
   async.eachSeries(entries, function(entry, next) {
     function _next() {
       i += 1;
-      next();
+      process.nextTick(function() {
+        next();
+      });
     }
 
     // Some servers include an official code-multiline sign at the beginning


### PR DESCRIPTION
I verified this in https://github.com/digitarald/flash-b2g which failed to list files for http://ftp.mozilla.org/pub/mozilla.org/b2g/nightly/ .
