### PR TITLE
fixed bug in regex constant RE_DOSEntry for digits in directory names

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -52,9 +52,10 @@ var RE_UnixEntry = new RegExp(
 var RE_DOSEntry = new RegExp(
   "(\\S+)\\s+(\\S+)\\s+" +
   "(<DIR>)?\\s*" +
-  "([0-9]+)?\\s*" +
+  "([0-9]+)?\\s{1,}" +
   "(\\S.*)"
 );
+
 
 // Not used for now
 // var RE_VMSEntry = new RegExp(

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -609,12 +609,19 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
         name: 'pub',
       },
       {
+        line: '11-18-03  10:16AM       <DIR>          2015',
+        type: 1,
+        size: 0,
+        time: +(new Date("11-18-03  10:16 AM")),
+        name: '2015',
+      },
+      {
         line: '04-14-99  03:47PM                  589 readme.htm',
         type: 0,
         size: 589,
         time: +(new Date("04-14-99  03:47 PM")),
         name: 'readme.htm'
-      }
+      }   
     ];
 
     dosEntries.forEach(function(entry) {


### PR DESCRIPTION
There is an issue in the regex for the dos systems. Added a test for this case.