### PR TITLE
Solution for MacOS "ls -l" command output.

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -28,7 +28,7 @@
 
 var RE_UnixEntry = new RegExp(
   "([bcdlfmpSs-])"
-    + "(((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-])))\\+?\\s+"
+    + "(((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-])))[\\+|@]?\\s+"
     + "(\\d+)\\s+"
     + "(\\S+)\\s+"
     + "(?:(\\S+)\\s+)?"


### PR DESCRIPTION
"ls -l" command output contains "@" character in permissions. Like, 
"-rw-r--r--@  1 user  staff   106020 Nov 13 19:25 photo.jpg".
Current RE_UnixEntry regular expression does not ersolve that and does not include files like this in return array.
Edited RE_UnixEntry regular expression for that.