### PR TITLE
FIXED: do not trim names that start with a space

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -28,21 +28,21 @@
 
 var RE_UnixEntry = new RegExp(
   "([bcdlfmpSs-])"
-    + "(((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-])))\\+?\\s+"
-    + "(\\d+)\\s+"
-    + "(\\S+)\\s+"
-    + "(?:(\\S+)\\s+)?"
-    + "(\\d+)\\s+"
+  + "(((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-]))((r|-)(w|-)([xsStTL-])))\\+?\\s+"
+  + "(\\d+)\\s+"
+  + "(\\S+)\\s+"
+  + "(?:(\\S+)\\s+)?"
+  + "(\\d+)\\s+"
 
-    //numeric or standard format date
-    + "((?:\\d+[-/]\\d+[-/]\\d+)|(?:\\S+\\s+\\S+))\\s+"
+  //numeric or standard format date
+  + "((?:\\d+[-/]\\d+[-/]\\d+)|(?:\\S+\\s+\\S+))\\s+"
 
-    // year (for non-recent standard format)
-    // or time (for numeric or recent standard format)
-    + "(\\d+(?::\\d+)?)\\s*"
+  // year (for non-recent standard format)
+  // or time (for numeric or recent standard format)
+  + "(\\d+(?::\\d+)?)\\s"
 
-    //+ "(\\S*)(\\s*.*)"
-    + "(.*)"
+  //+ "(\\S*)(\\s*.*)"
+  + "(.*)"
 );
 
 // MSDOS format
@@ -101,7 +101,7 @@ exports.parseFtpEntries = function parseFtpEntries(listing, callback) {
   var i = 0;
   var parsed = [];
   var entries = splitEntries(listing);
-  entries.forEach(function(entry, i) {
+  entries.forEach(function (entry, i) {
     // Some servers include an official code-multiline sign at the beginning
     // of every string. We must strip it if that's the case.
     if (RE_MULTI.test(entry)) {
@@ -150,10 +150,10 @@ exports.parseFtpEntries = function parseFtpEntries(listing, callback) {
  * @param entries {Array.<string>|string} FTP file entry line.
  * @param callback {Function} Callback function with error or result.
  */
-exports.parseEntries = function(entries, callback) {
+exports.parseEntries = function (entries, callback) {
   callback(null, splitEntries(entries)
     .map(parseEntry)
-    .filter(function(entry) { return !!entry; }));
+    .filter(function (entry) { return !!entry; }));
 };
 
 /**
@@ -163,7 +163,7 @@ exports.parseEntries = function(entries, callback) {
  * @param entry {string} FTP file entry line
  * @returns {Object|null} Parsed object with the file entry properties
  */
-var parseEntry = exports.parseEntry = function(entry) {
+var parseEntry = exports.parseEntry = function (entry) {
   var c = entry.charAt(0);
 
   if ('bcdlps-'.indexOf(c) > -1) {
@@ -177,7 +177,7 @@ var parseEntry = exports.parseEntry = function(entry) {
 };
 
 var parsers = {
-  unix: function(entry) {
+  unix: function (entry) {
     var target, writePerm, readPerm, execPerm;
     var group = entry.match(RE_UnixEntry);
 
@@ -245,7 +245,7 @@ var parsers = {
       if (target) file.target = target;
 
       var g = 4;
-      ["user", "group", "other"].forEach(function(access) {
+      ["user", "group", "other"].forEach(function (access) {
         // Use != '-' to avoid having to check for suid and sticky bits
         readPerm = group[g] !== "-";
         writePerm = group[g + 1] !== "-";
@@ -265,7 +265,7 @@ var parsers = {
     }
   },
 
-  msdos: function(entry) {
+  msdos: function (entry) {
     var group = entry.match(RE_DOSEntry);
     var type;
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -10,8 +10,8 @@
 var assert = require("assert");
 var Parser = require("../src/parser");
 
-describe("jsftp file listing parser", function() {
-  it("test ftp unix STAT responses", function() {
+describe("jsftp file listing parser", function () {
+  it("test ftp unix STAT responses", function () {
     var str = "drwxr-xr-x    5 1001     1001         4096 Jan 09 11:52 .\r\n\
 drwxr-xr-x    4 0        0            4096 Sep 19 13:50 ..\r\n\
 -rw-------    1 1001     1001         1118 Jan 09 12:09 .bash_history\r\n\
@@ -123,8 +123,8 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
       }
     ];
 
-    Parser.parseEntries(str, function(err, entryArray) {
-      entryArray.forEach(function(entry, i) {
+    Parser.parseEntries(str, function (err, entryArray) {
+      entryArray.forEach(function (entry, i) {
         assert.equal(unixEntries[i].type, entry.type);
         assert.equal(unixEntries[i].size, entry.size);
         assert.equal(unixEntries[i].name, entry.name);
@@ -147,7 +147,7 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
     })
   });
 
-  it("test ftp unix LIST responses", function() {
+  it("test ftp unix LIST responses", function () {
     var str = "drwx--x---  10 mrclash  adm          4096 Aug  9 14:48 .\r\n\
  drwx--x---  10 mrclash  adm          4096 Aug  9 14:48 ..\r\n\
  -rw-r--r--   1 mrclash  pg223090      260 Mar 25  2008 .alias\r\n\
@@ -544,8 +544,8 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
       }
     ];
 
-    Parser.parseEntries(str, function(err, entryArray) {
-      entryArray.forEach(function(entry, i) {
+    Parser.parseEntries(str, function (err, entryArray) {
+      entryArray.forEach(function (entry, i) {
         assert.equal(unixEntries[i].type, entry.type);
         assert.equal(unixEntries[i].size, entry.size);
         assert.equal(unixEntries[i].name, entry.name);
@@ -567,8 +567,8 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
       });
     });
 
-    Parser.parseEntries(str2, function(err, entryArray) {
-      entryArray.forEach(function(entry, i) {
+    Parser.parseEntries(str2, function (err, entryArray) {
+      entryArray.forEach(function (entry, i) {
         assert.equal(unixEntries2[i].type, entry.type);
         assert.equal(unixEntries2[i].size, entry.size);
         assert.equal(unixEntries2[i].name, entry.name);
@@ -592,7 +592,7 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
   });
 
 
-  it("test ftp windows/DOS LIST responses", function() {
+  it("test ftp windows/DOS LIST responses", function () {
     var dosEntries = [
       {
         line: '04-27-00  09:09PM       <DIR>          licensed',
@@ -621,10 +621,10 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
         size: 589,
         time: +(new Date("04-14-99  03:47 PM")),
         name: 'readme.htm'
-      }   
+      }
     ];
 
-    dosEntries.forEach(function(entry) {
+    dosEntries.forEach(function (entry) {
       var result = Parser.parseEntry(entry.line);
 
       assert.equal(result.type, entry.type);
@@ -634,7 +634,7 @@ drwx------    2 1001     1001         4096 Oct 19 16:17 project2\r\n";
     });
   });
 
-  it("test FTP listing with bad line breaks", function(next) {
+  it("test FTP listing with bad line breaks", function (next) {
     var badStr = "\
 213-Status follows:\r\n\
 -rw-r--r-- 1 0 0 105981956 Dec 20 18:07 GAT\r\n\
@@ -645,7 +645,7 @@ arie\r\n\
 drwxr-xr-x    2 0        0            4096 Apr 16  2011 denton\r\n\
 213 End of status";
 
-    Parser.parseFtpEntries(badStr, function(err, entries) {
+    Parser.parseFtpEntries(badStr, function (err, entries) {
       assert.equal("GATSBY.MPG", entries[0].name);
       assert.equal("GIJO.MPG", entries[1].name);
       assert.equal("bourdarie", entries[2].name);
@@ -654,6 +654,17 @@ drwxr-xr-x    2 0        0            4096 Apr 16  2011 denton\r\n\
     });
   });
 
+  it("test FTP listing with names starting with one or more spaces", function (next) {
+    var str = "\
+    --rw-r-----   1 userName alternc       460 Aug 22 03:45  test1\r\n\
+    --rw-r-----   1 userName alternc       560 Aug 22 03:47   test2\r\n";
+
+    Parser.parseFtpEntries(str, function (err, entries) {
+      assert.equal(" test1", entries[0].name);
+      assert.equal("  test2", entries[1].name);
+      next();
+    });
+  });
 
   /*
    * We are not supporting MLSx commands yet


### PR DESCRIPTION
If filenames started with a space (which is a valid name in Unix), these spaces would be removed from the returned listing, returning.

For example:

```
--rw-r-----   1 userName alternc       460 Aug 22 03:45  test1
--rw-r-----   1 userName alternc       560 Aug 22 03:47   test2
```

Would return two wrong names: `"test1"` and `"test2"` instead of `" test1"` and `"  test2"`.

I added a new test for this particular case.